### PR TITLE
added api setup into node build fixes-#22

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,9 @@ BANNED PACKAGES
 
 * Install Postman https://www.getpostman.com/
 * Install gcc (windows https://sourceforge.net/projects/mingw-w64/?source=typ_redirect)
-* Go to api/ and create 3 folders bin, pkg and src
-* Run ``` go get github.com/gin-gonic/gin ```
-* Run ``` go get github.com/jinzhu/gorm ```
-* Run ``` go get github.com/mattn/go-sqlite3 ```
-* Run ``` go install github.com/mattn/go-sqlite3 // need gcc ```
-* Run ``` go build ```
-* Run ``` ./api.exe ```
+* Run ` npm run build ` or ` npm run dev ` To setup, install and build go packages 
+* The executable will be built in /api/bin/api.exe
+* Run ` go build ` for subsequent builds
 * Open up Postman and use it to use the api and stuff
 
 ### Front End

--- a/build/build.js
+++ b/build/build.js
@@ -1,6 +1,7 @@
 // https://github.com/shelljs/shelljs
 require("./check-versions")();
 require("shelljs/global");
+var utils = require("./utils");
 env.NODE_ENV = "production";
 
 var path = require("path");
@@ -8,6 +9,8 @@ var config = require("../config");
 var ora = require("ora");
 var webpack = require("webpack");
 var webpackConfig = require("./webpack.prod.conf");
+
+utils.apiSetup();
 
 console.log(
 	"  Tip:\n" +

--- a/build/dev-server.js
+++ b/build/dev-server.js
@@ -7,6 +7,9 @@ var webpack = require("webpack");
 var opn = require("opn");
 var proxyMiddleware = require("http-proxy-middleware");
 var webpackConfig = require("./webpack.dev.conf");
+var utils = require("./utils");
+
+utils.apiSetup();
 
 // default port where dev server listens for incoming traffic
 var port = process.env.PORT || config.dev.port;

--- a/build/utils.js
+++ b/build/utils.js
@@ -1,6 +1,8 @@
 var path = require("path");
 var config = require("../config");
 var ExtractTextPlugin = require("extract-text-webpack-plugin");
+var ora = require("ora");
+require("shelljs/global");
 
 exports.assetsPath = function (_path) {
 	var assetsSubDirectory = process.env.NODE_ENV === "production"
@@ -65,3 +67,22 @@ exports.styleLoaders = function (options) {
 	}
 	return output;
 };
+
+exports.apiSetup = function (options) {
+	var spinner = ora("setting up api...");
+	spinner.start();
+	mkdir("-p", path.join(__dirname, config.build.apiDirectory, "bin"));
+	mkdir("-p", path.join(__dirname, config.build.apiDirectory, "pkg"));
+	mkdir("-p", path.join(__dirname, config.build.apiDirectory, "src"));
+	process.env["GOPATH"] = path.join(__dirname, config.build.apiDirectory);
+	process.env["GOBIN"] = path.join(__dirname, config.build.apiDirectory, "bin");
+	const exec = require('child_process').exec;
+	exec("cd api && go get", (error, stdout, stderr) => {
+		if (error) {
+			console.error(`\nGO ${error}`);
+			return;
+		}
+	});
+	spinner.stop();
+	return true;
+}

--- a/config/index.js
+++ b/config/index.js
@@ -9,6 +9,7 @@ module.exports = {
 		assetsSubDirectory: "static",
 		assetsPublicPath: "",
 		productionSourceMap: true,
+		apiDirectory: "../api",
 		// Gzip off by default as many popular static hosts such as
 		// Surge or Netlify already gzip all static assets for you.
 		// Before setting to `true`, make sure to:


### PR DESCRIPTION
Added a api setup in the node build for build and dev which basically creates the files needed for go to download and install packages.

basically gets rid of the complexity from the api setup

It also doesn't break the build if the packages cannot be downloaded due to no internet or if there is any other error it will just spit out the error message in the console