### PR TITLE
Fix #25 Added workspace settings to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,9 @@ dist/
 *.swp
 .editorconfig
 .vs/
-.vscode/
+
+# Allow .vscode for workspace settings
+# .vscode/
 
 # Logs
 logs

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "editor.rulers": [
+        80,
+        120
+    ],
+    "editor.tabSize": 4,
+    "editor.insertSpaces": false
+}


### PR DESCRIPTION
The settings.json inside of the .vscode folder should override the default user settings according to [https://code.visualstudio.com/docs/getstarted/settings](https://code.visualstudio.com/docs/getstarted/settings)
+ Changed default indentation to tabs
+ Added workspace folder to repo